### PR TITLE
add a flake

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,7 @@
+.DS_Store
+.idea
+*.log
+tmp/
+
+# just now we don't want to lock
+flake.lock

--- a/README.md
+++ b/README.md
@@ -32,6 +32,38 @@ $ sudo dd if=./result of=/dev/mmcblk0 iflag=direct oflag=direct bs=16M status=pr
 
 Replace `/dev/mmcblk0` with your actual device.
 
+## Flakes support
+
+Flakes support is also provided. This repository has no dependencies except for nixpkgs, however we do not provide a
+lock file which means that one will be created using your system if you pull down the repo. This lets you use an
+up-to-date uboot at whatever level of stability you are already comfortable with.
+
+To build the `rockPro64` image without pulling down the repo, use:
+```
+nix build --no-write-lock-file 'github:Mic92/nixos-aarch64-images#rockPro64'
+```
+
+To build the `rockPro64` image without pulling down the repo and switching nixpkgs with nixpkgs-unstable:
+```
+nix build --no-write-lock-file --override-input nixpkgs github:nixos/nixpkgs/nixpkgs-unstable 'github:Mic92/nixos-aarch64-images#rockPro64'
+```
+
+Of course, you can replace `rockPro64` with any of the outputs included in this flake. To see the outputs, you can
+invoke `nix flake show`:
+
+```
+❯ nix flake show
+git+file:///home/user/git/nixos-aarch64-images
+└───packages
+    └───x86_64-linux
+        ├───aarch64Image: package 'aarch64-image'
+        ├───pinebookPro: package 'image'
+        ├───roc-pc-rk3399: package 'image'
+        ├───rock64: package 'image'
+        └───rockPro64: package 'image'
+```
+
+
 ## Supported boards
 
 | Board                            | Attribute     | Status                                             |

--- a/default.nix
+++ b/default.nix
@@ -12,7 +12,7 @@ let
     inherit aarch64Image buildImage;
   };
 in {
-  inherit aarch64Image aarch64Pkgs;
+  inherit aarch64Image;
 
   rock64 = rockchip aarch64Pkgs.ubootRock64;
   rockPro64 = rockchip aarch64Pkgs.ubootRockPro64;

--- a/flake.nix
+++ b/flake.nix
@@ -3,20 +3,9 @@
   # pin this to unstable
   # inputs.nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
 
-  outputs = { self, nixpkgs }:
-    let
-      supportedSystems = [ "x86_64-linux" ];
-      forAllSystems = f:
-        nixpkgs.lib.genAttrs supportedSystems (system: f system);
-      nixpkgsFor = forAllSystems (system: import nixpkgs { inherit system; });
-    in {
-      packages = forAllSystems (system:
-        let
-          pkgs = import nixpkgs { inherit system; };
-          aarch64imgs = pkgs.callPackage ./. { };
-        in {
-          inherit (aarch64imgs)
-            aarch64Image rock64 rockPro64 roc-pc-rk3399 pinebookPro;
-        });
+  outputs = { self, nixpkgs }: {
+    packages.x86_64-linux = import ./. {
+      pkgs = nixpkgs.legacyPackages.x86_64-linux;
     };
+  };
 }

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,22 @@
+{
+  description = "Build NixOS images for various ARM single computer boards";
+  # pin this to unstable
+  # inputs.nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
+
+  outputs = { self, nixpkgs }:
+    let
+      supportedSystems = [ "x86_64-linux" ];
+      forAllSystems = f:
+        nixpkgs.lib.genAttrs supportedSystems (system: f system);
+      nixpkgsFor = forAllSystems (system: import nixpkgs { inherit system; });
+    in {
+      packages = forAllSystems (system:
+        let
+          pkgs = import nixpkgs { inherit system; };
+          aarch64imgs = pkgs.callPackage ./. { };
+        in {
+          inherit (aarch64imgs)
+            aarch64Image rock64 rockPro64 roc-pc-rk3399 pinebookPro;
+        });
+    };
+}


### PR DESCRIPTION
this probably needs some documentation, but with this flake you no longer have to pull down the repo. You can just invoke the following:

```
❯ nix build --no-write-lock-file 'github:stites/nixos-aarch64-images/flakeit#rockPro64'
```

I didn't include a lock file because I didn't think it was needed.

```
❯ nix flake show
git+file:///home/stites/git/nixos-aarch64-images
└───packages
    └───x86_64-linux
        ├───aarch64Image: package 'aarch64-image'
        ├───pinebookPro: package 'image'
        ├───roc-pc-rk3399: package 'image'
        ├───rock64: package 'image'
        └───rockPro64: package 'image'
```
