### PR TITLE
Use pkgsCross for cross-compiling.

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -1,9 +1,7 @@
 { pkgs ? import <nixpkgs> {} }:
 
 let
-  aarch64Pkgs = import pkgs.path {
-    system = "aarch64-linux";
-  };
+  aarch64Pkgs = pkgs.pkgsCross.aarch64-multiplatform;
 
   buildImage = pkgs.callPackage ./pkgs/build-image {};
   aarch64Image = pkgs.callPackage ./pkgs/aarch64-image {};


### PR DESCRIPTION
For me, this fixes #10. The packages don't all come from cache, but they get built locally with the cross-compiler.