### PR TITLE
build-image: properly split calculated size, use util-linux instead of utillinux

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -2,19 +2,18 @@
   "nodes": {
     "nixpkgs": {
       "locked": {
-        "lastModified": 1733935885,
-        "narHash": "sha256-xyiHLs6KJ1fxeGmcCxKjJE4yJknVJxbC8Y/ZRYyC8WE=",
-        "ref": "nixpkgs-unstable",
-        "rev": "5a48e3c2e435e95103d56590188cfed7b70e108c",
-        "shallow": true,
-        "type": "git",
-        "url": "https://github.com/NixOS/nixpkgs"
+        "lastModified": 1781074563,
+        "narHash": "sha256-md8WlXOlfnIeHeOScMTTHFyf2d6iaTwPl2apR5EQ3P4=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "9ae611a455b90cf061d8f332b977e387bda8e1ca",
+        "type": "github"
       },
       "original": {
-        "ref": "nixpkgs-unstable",
-        "shallow": true,
-        "type": "git",
-        "url": "https://github.com/NixOS/nixpkgs"
+        "owner": "nixos",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
       }
     },
     "root": {

--- a/flake.nix
+++ b/flake.nix
@@ -1,7 +1,7 @@
 {
   description = "Build NixOS images for various ARM single computer boards";
   # pin this to unstable
-  inputs.nixpkgs.url = "git+https://github.com/NixOS/nixpkgs?shallow=1&ref=nixpkgs-unstable";
+  inputs.nixpkgs.url = "github:nixos/nixpkgs/nixos-unstable";
 
   outputs = { nixpkgs, ... }: {
     packages.x86_64-linux = import ./. {

--- a/pkgs/build-image/build-image.py
+++ b/pkgs/build-image/build-image.py
@@ -93,8 +93,8 @@ class Partition:
             return self._calculated_size
 
         cmd = ["du", "-B", "512", "--apparent-size", self.source]
-        proc = subprocess.run(cmd, check=True, stdout=subprocess.PIPE)
-        self._calculated_size = int(proc.stdout)
+        proc = subprocess.run(cmd, check=True, stdout=subprocess.PIPE, text=True)
+        self._calculated_size = int(proc.stdout.split("\t")[0])
         return self._calculated_size
 
 

--- a/pkgs/build-image/default.nix
+++ b/pkgs/build-image/default.nix
@@ -1,4 +1,4 @@
-{ lib, writeText, utillinux, stdenv, python3 }:
+{ lib, writeText, util-linux, stdenv, python3 }:
 
 { config }:
 let
@@ -20,7 +20,7 @@ in stdenv.mkDerivation {
   dontPatchShebangs = true;
 
   nativeBuildInputs = [
-    python3 utillinux
+    python3 util-linux
   ];
   buildPhase = ''
     runHook preBuild


### PR DESCRIPTION
without these, builds fail on more recent nixpkgs